### PR TITLE
fix: accept case-insensitive basic auth scheme

### DIFF
--- a/maas/maas-service/utils/utils.go
+++ b/maas/maas-service/utils/utils.go
@@ -60,21 +60,21 @@ func CreateContextFromString(rId string) context.Context {
 	return context.WithValue(context.Background(), requestIDContextKey, rId)
 }
 func GetBasicAuth(fiberCtx fiber.Ctx) (string, SecretString, error) {
-	var basicAuthPrefix = []byte("Basic ")
 	var username string
 	var password SecretString
-	auth := fiberCtx.Request().Header.Peek(fiber.HeaderAuthorization)
+	auth := string(fiberCtx.Request().Header.Peek(fiber.HeaderAuthorization))
 
 	if len(auth) == 0 {
 		return "", "", fmt.Errorf("header `%v' is empty: %w", fiber.HeaderAuthorization, msg.AuthError)
 	}
 
-	if !bytes.HasPrefix(auth, basicAuthPrefix) {
+	scheme, creds, ok := ParseAuthHeader(auth)
+	if !ok || !strings.EqualFold(scheme, "basic") {
 		return "", "", fmt.Errorf("not a basic auth, should have prefix 'Basic': %w", msg.AuthError)
 	}
 
 	// Check credentials
-	payload, err := base64.StdEncoding.DecodeString(string(auth[len(basicAuthPrefix):]))
+	payload, err := base64.StdEncoding.DecodeString(creds)
 	if err != nil {
 		return "", "", fmt.Errorf("error during decoding auth string")
 	}

--- a/maas/maas-service/utils/utils_test.go
+++ b/maas/maas-service/utils/utils_test.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	_assert "github.com/stretchr/testify/assert"
 	"math/rand"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/gofiber/fiber/v3"
+	_assert "github.com/stretchr/testify/assert"
 )
 
 type void struct{}
@@ -509,6 +512,58 @@ func TestParseAuthHeader(t *testing.T) {
 			if creds != tt.creds {
 				t.Errorf("expected user creds=%q, got %q", tt.creds, creds)
 			}
+		})
+	}
+}
+
+func TestGetBasicAuth(t *testing.T) {
+	// base64("user:pass") == "dXNlcjpwYXNz"
+	const validCreds = "dXNlcjpwYXNz"
+
+	tests := []struct {
+		name    string
+		header  string
+		user    string
+		pass    string
+		wantErr bool
+	}{
+		{name: "canonical Basic", header: "Basic " + validCreds, user: "user", pass: "pass"},
+		{name: "lowercase basic", header: "basic " + validCreds, user: "user", pass: "pass"},
+		{name: "uppercase BASIC", header: "BASIC " + validCreds, user: "user", pass: "pass"},
+		{name: "mixed-case bAsIc", header: "bAsIc " + validCreds, user: "user", pass: "pass"},
+		{name: "empty header", header: "", wantErr: true},
+		{name: "not basic scheme", header: "Bearer sometoken", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := _assert.New(t)
+
+			var (
+				gotUser string
+				gotPass SecretString
+				gotErr  error
+			)
+			app := fiber.New()
+			app.Get("/", func(c fiber.Ctx) error {
+				gotUser, gotPass, gotErr = GetBasicAuth(c)
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.header != "" {
+				req.Header.Set(fiber.HeaderAuthorization, tt.header)
+			}
+			_, err := app.Test(req)
+			assert.NoError(err)
+
+			if tt.wantErr {
+				assert.Error(gotErr)
+				return
+			}
+			assert.NoError(gotErr)
+			assert.Equal(tt.user, gotUser)
+			assert.Equal(tt.pass, string(gotPass))
 		})
 	}
 }


### PR DESCRIPTION
GetBasicAuth checked the Authorization header with a case-sensitive prefix "Basic ", while ParseAuthHeader (the m2m entry point) matches the scheme case-insensitively. A client sending `basic <creds>` (lowercase) passed ParseAuthHeader but was rejected by GetBasicAuth, failing every request (e.g. Kafka topic registration).

Parse via ParseAuthHeader and compare with strings.EqualFold so Basic, basic and BASIC are all accepted (RFC 7235).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Basic-auth requests were rejected whenever the client sent the scheme in a
non-canonical case, e.g. `Authorization: basic <creds>` (lowercase `b`). Such
requests failed authentication and never reached the handler. For example,
`POST /api/v1/kafka/topic` returned `403 Forbidden` with:

```
security middleware error: not a basic auth, should have prefix 'Basic': authentication error
```

**Root cause.** The `Authorization` header is parsed in two inconsistent places:

- `utils.ParseAuthHeader`, the auth entry point used by the security
  middleware, matches the scheme **case-insensitively** (regex `(?i)`), so
  `basic` / `Basic` / `BASIC` are all accepted and routed to the basic branch.
- `utils.GetBasicAuth`, invoked from that branch, re-read the raw header and
  validated it with a **case-sensitive** byte prefix `"Basic "`.

A lowercase `basic <creds>` therefore passed `ParseAuthHeader` but was rejected
by `GetBasicAuth`. Per RFC 7235 the HTTP auth-scheme is case-insensitive,
so the service must accept any casing.

**Fix.** `GetBasicAuth` no longer re-implements header parsing: it parses through
the single source of truth `ParseAuthHeader` and checks the scheme with
`strings.EqualFold(scheme, "basic")`. This removes the second, inconsistent
parser and makes the whole auth path case-insensitive. `GetBasicAuth` is used by
both the security middleware and request logging, so both call sites are fixed.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue: N/A
- Closes: N/A

## QA Instructions, Screenshots, Recordings

- Unit: `cd maas/maas-service && go test ./utils/ -run TestGetBasicAuth` passes
  for `Basic`, `basic`, `BASIC`, mixed-case `bAsIc`, and correctly rejects an
  empty header and a non-basic scheme.
- Manual: send a request with a lowercase scheme, e.g.
  `curl -H "Authorization: basic $(printf 'user:pass' | base64)" ...` against a
  protected endpoint, and the request is now authenticated instead of returning
  `403 not a basic auth`.

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

_No breaking changes: no deployment parameters are added/renamed and no request/response
contract changes. Clients already sending canonical `Basic` are unaffected; the change
only broadens the accepted scheme casing._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check?

- The `controller` package tests (security middleware end-to-end) require a
  PostgreSQL testcontainer / Docker and were not run in this environment; the fix
  is covered at the unit level in `utils`.
- `GetBasicAuth` is called from two places (security middleware and request
  logging), and both benefit from the single fix.

## [optional] What gif best describes this PR or how it makes you feel?
