### PR TITLE
fix(deps): fix response code when M2M is enabled

### DIFF
--- a/maas/maas-service/controller/controller_common_funcs.go
+++ b/maas/maas-service/controller/controller_common_funcs.go
@@ -99,13 +99,13 @@ func SecurityMiddleware(roles []model.RoleName, authorizeWithBasic authorizeWith
 			compositeIsolationDisabled = strings.ToLower(string(ctx.Request().Header.Peek(HeaderXCompositeIsolationDisabled))) == "disabled"
 		case "bearer":
 			if authorizeWithToken == nil {
-				return utils.LogError(log, userCtx, "kubernetes m2m authentication is not enabled, use basic or set KUBERNETES_M2M_ENABLED=true: %w", msg.AuthError)
+				return utils.LogError(log, userCtx, "kubernetes m2m authentication is not enabled, use basic or set KUBERNETES_M2M_ENABLED=true: %w", msg.UnauthorizedError)
 			}
 
 			var err error
 			account, err = authorizeWithToken(userCtx, creds, roles)
 			if err != nil {
-				return utils.LogError(log, userCtx, "request authorization failure: %w", err)
+				return utils.LogError(log, userCtx, "request authorization failure: %v: %w", err, msg.UnauthorizedError)
 			}
 
 			ctx.Request().Header.Add(HeaderXMicroservice, account.Username)
@@ -325,6 +325,8 @@ func TmfErrorHandler(ctx fiber.Ctx, err error) error {
 		code = http.StatusForbidden
 	case errors.Is(err, msg.Gone):
 		code = http.StatusGone
+	case errors.Is(err, msg.UnauthorizedError):
+		code = http.StatusUnauthorized
 	case errors.Is(err, dao.DatabaseIsNotActiveError):
 		code = http.StatusMethodNotAllowed
 	case errors.Is(err, dao.DatabaseIsReadonlyError):

--- a/maas/maas-service/controller/controller_common_funcs_test.go
+++ b/maas/maas-service/controller/controller_common_funcs_test.go
@@ -137,7 +137,7 @@ func TestSecurityMiddleware_Anonymous(t *testing.T) {
 		resp, err = app.Test(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 		// pass a nil authorizeWithTokenFunc to SecurityMiddleware to turn off k8s m2m
 		app.Get("/anonymous-without-k8s-m2m", SecurityMiddleware([]model.RoleName{model.AnonymousRole, testRoleName}, authService.IsAccessGrantedWithBasic, nil), func(ctx fiber.Ctx) error {
@@ -149,7 +149,7 @@ func TestSecurityMiddleware_Anonymous(t *testing.T) {
 		resp, err = app.Test(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
 }
 

--- a/maas/maas-service/msg/msg.go
+++ b/maas/maas-service/msg/msg.go
@@ -13,6 +13,8 @@ var (
 	Conflict = errors.New("conflict error") // 409
 	//nolint:staticcheck // ST1012: legacy exported names used across the project
 	Gone = errors.New("entity gone") // 410
+	//nolint:staticcheck // ST1012: legacy exported names used across the project
+	UnauthorizedError = errors.New("unauthorized error") // 401
 )
 
 const InvalidClassifierFormat = "invalid classifier '%v': %w"

--- a/maas/maas-service/router/api_test.go
+++ b/maas/maas-service/router/api_test.go
@@ -108,7 +108,7 @@ spec:
 		resp, err := app.Test(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed the HTTP response code for Bearer token authentication errors in SecurityMiddleware.

Previously, errors in the case "bearer" branch returned 403 Forbidden, even though these cases should return 401 Unauthorized (invalid/missing token, M2M disabled, JWT verification failure).

Changes:

In SecurityMiddleware, case "bearer" errors now use msg.UnauthorizedError instead of msg.AuthError
Added msg.UnauthorizedError (401)
Added mapping in TmfErrorHandler: UnauthorizedError → 401 Unauthorized
Updated unit tests for bearer scenarios
Unchanged:

basic auth and other authorization paths still return 403
IsAccessGrantedWithToken logic in the auth service was not modified; response code remapping is done only in the middleware for bearer requests



## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
